### PR TITLE
Add default server group assignment script to Forge.

### DIFF
--- a/actions/cloudbolt_plugins/add_users_to_default_group_on_login/README.md
+++ b/actions/cloudbolt_plugins/add_users_to_default_group_on_login/README.md
@@ -1,0 +1,5 @@
+This plugin adds any user logging in to a default group (line 9). This can be used to facilitate automatic assignment of new users to a default group so they can request servers from their first use.
+
+In this instance, the users are assigned Requestor and Approver permissions on the group, and the Viewer permission is removed. This enables users to request and manage their own servers without being able to see others in the group.
+
+This plugin should be used as part of the **Other | External Users Sync** orchestration hook.

--- a/actions/cloudbolt_plugins/add_users_to_default_group_on_login/add_users_to_default_server_group_on_login.json
+++ b/actions/cloudbolt_plugins/add_users_to_default_group_on_login/add_users_to_default_server_group_on_login.json
@@ -1,0 +1,6 @@
+{
+    "name": "Add users to default group on login",
+    "resource-technologies": [],
+    "script-filename": "cbDefaultGroupAssignment.py",
+    "type": "CloudBolt Plug-in"
+}

--- a/actions/cloudbolt_plugins/add_users_to_default_group_on_login/cbDefaultGroupAssignment.py
+++ b/actions/cloudbolt_plugins/add_users_to_default_group_on_login/cbDefaultGroupAssignment.py
@@ -1,0 +1,21 @@
+import sys
+from accounts.models import Group, GroupType, UserProfile
+
+def run(job, logger=None, **kwargs):
+    logger.debug("Running hook {}".format(__name__), logger)
+    users = kwargs.get('users', None)
+    for user_profile in users:
+        # Set the default group below by name or ID.
+        g = Group.objects.filter(name="Default Group").first()
+        logger.debug("Got user %s", user_profile.id)
+        logger.debug("Group: %s", g.name)
+        if g.is_resource_admin(user_profile):
+            # Bypass setting permissions if the user is a Resource Admin in group.
+            logger.debug("User is group admin")
+        else:
+            user_profile.requestors.add(g)
+            user_profile.approvers.add(g)
+            user_profile.viewers.remove(g)
+
+        logger.debug("Completed.")
+    return "", "", ""


### PR DESCRIPTION
This script can be added as an orchestration hook to assign any user on login to a defined group with specific permissions.