### PR TITLE
Add GKE Cluster blueprint

### DIFF
--- a/blueprints/gke_cluster/create_gke_cluster/create_gke_cluster.json
+++ b/blueprints/gke_cluster/create_gke_cluster/create_gke_cluster.json
@@ -1,0 +1,45 @@
+{
+    "action-inputs": [
+        {
+            "available-all-servers": false,
+            "description": null,
+            "hide-if-default-value": false,
+            "label": "Cloudbolt Environment",
+            "name": "cloudbolt_environment",
+            "required": true,
+            "show-as-attribute": false,
+            "show-on-servers": false,
+            "type": "STR"
+        },
+        {
+            "available-all-servers": false,
+            "description": null,
+            "hide-if-default-value": false,
+            "label": "Name",
+            "name": "name",
+            "required": true,
+            "show-as-attribute": false,
+            "show-on-servers": false,
+            "type": "STR"
+        },
+        {
+            "available-all-servers": false,
+            "description": "",
+            "hide-if-default-value": false,
+            "label": "Node Count",
+            "name": "node_count",
+            "required": false,
+            "show-as-attribute": false,
+            "show-on-servers": false,
+            "type": "INT"
+        }
+    ],
+    "description": "",
+    "max-retries": 0,
+    "name": "Create GKE Cluster",
+    "resource-technologies": [],
+    "script-filename": "create_gke_cluster.py",
+    "shared": "False",
+    "target-os-families": [],
+    "type": "CloudBolt Plug-in"
+}

--- a/blueprints/gke_cluster/create_gke_cluster/create_gke_cluster.py
+++ b/blueprints/gke_cluster/create_gke_cluster/create_gke_cluster.py
@@ -1,0 +1,238 @@
+"""
+Creates a Kubernetes cluster in Google Kubernetes Engine and add it as a
+Container Orchestrator in CloudBolt.
+
+To use this, you must have a Google Compute Engine resource handler set up in
+CloudBolt, and it must have a zone.
+
+Takes 3 inputs:
+    * CloudBolt environment: the environment to provision the cluster nodes in
+    * Cluster name: the name of the new cluster (must be unique)
+    * Node count (optional): the number of nodes to provision (default=1)
+"""
+from __future__ import unicode_literals
+import hashlib
+import time
+
+from django.urls import reverse
+from googleapiclient.discovery import build
+from oauth2client.service_account import ServiceAccountCredentials
+
+from containerorchestrators.models import ContainerOrchestratorTechnology
+from containerorchestrators.kuberneteshandler.models import Kubernetes
+from infrastructure.models import CustomField, Environment, Server
+from portals.models import PortalConfig
+
+ENV_ID = '{{ cloudbolt_environment }}'
+CLUSTER_NAME = '{{ name }}'
+try:
+    NODE_COUNT = int('{{ node_count }}')
+except ValueError:
+    NODE_COUNT = 1
+TIMEOUT = 1800  # 30 minutes
+
+
+class GKEClusterBuilder(object):
+    def __init__(self, environment, cluster_name):
+        self.environment = environment
+        self.cluster_name = cluster_name
+        self.handler = environment.resource_handler.cast()
+        self.zone = environment.node_location
+        self.project = self.handler.project
+
+        self.credentials = ServiceAccountCredentials.from_json_keyfile_dict({
+            'client_email': self.handler.serviceaccount,
+            'private_key': self.handler.servicepasswd,
+            'type': 'service_account',
+            'client_id': None,
+            'private_key_id': None,
+        })
+        self.container_client = self.get_client('container')
+        self.compute_client = self.get_client('compute')
+
+    def get_client(self, serviceName, version='v1'):
+        return build(serviceName, version, credentials=self.credentials)
+
+    def create_cluster(self, node_count):
+        cluster_resource = self.container_client.projects().zones().clusters()
+        request = cluster_resource.create(
+            projectId=self.project, zone=self.zone, body={
+                'cluster': {
+                    'name': self.cluster_name,
+                    'initial_node_count': node_count,
+                }
+            })
+        return request.execute()
+
+    def get_cluster(self):
+        cluster_resource = self.container_client.projects().zones().clusters()
+        request = cluster_resource.get(
+            projectId=self.project,
+            zone=self.zone,
+            clusterId=self.cluster_name,
+        )
+        return request.execute()
+
+    def wait_for_endpoint(self, timeout=None):
+        endpoint = None
+        start = time.time()
+        while not endpoint:
+            if timeout is not None and (time.time() - start > timeout):
+                break
+            cluster = self.get_cluster()
+            endpoint = cluster.get('endpoint')
+            time.sleep(5)
+        return endpoint
+
+    def wait_for_nodes(self, node_count, timeout=None):
+        nodes = []
+        start = time.time()
+        while len(nodes) < node_count:
+            if timeout is not None and (time.time() - start > timeout):
+                break
+            request = self.compute_client.instances().list(
+                project=self.project, zone=self.zone,
+                filter="name:gke-{}-default-pool*".format(self.cluster_name))
+            response = request.execute()
+            nodes = response.get('items') or []
+            time.sleep(5)
+        return nodes
+
+    def wait_for_running_status(self, timeout=None):
+        status = ''
+        start = time.time()
+        while status != 'RUNNING':
+            if timeout is not None and (time.time() - start > timeout):
+                break
+            cluster = self.get_cluster()
+            status = cluster.get('status')
+            time.sleep(5)
+        return status
+
+
+def generate_options_for_cloudbolt_environment(group=None, **kwargs):
+    """
+    List all GCE environments that are orderable by the current group.
+    """
+    envs = Environment.objects.filter(
+        resource_handler__resource_technology__name='Google Compute Engine') \
+        .select_related('resource_handler')
+    if group:
+        group_env_ids = [env.id for env in group.get_available_environments()]
+        envs = envs.filter(id__in=group_env_ids)
+    return [
+        (env.id, u'{env} ({project})'.format(
+            env=env, project=env.resource_handler.cast().project))
+        for env in envs
+    ]
+
+
+def create_required_parameters():
+    CustomField.objects.get_or_create(
+        name='create_gke_k8s_cluster_env',
+        defaults=dict(
+            label="GKE Cluster: Environment",
+            description="Used by the GKE Cluster blueprint",
+            type="INT"
+        ))
+    CustomField.objects.get_or_create(
+        name='create_gke_k8s_cluster_name',
+        defaults=dict(
+            label="GKE Cluster: Cluster Name",
+            description="Used by the GKE Cluster blueprint",
+            type="STR"
+        ))
+    CustomField.objects.get_or_create(
+        name='create_gke_k8s_cluster_id',
+        defaults=dict(
+            label="GKE Cluster: Cluster ID",
+            description="Used by the GKE Cluster blueprint",
+            type="INT",
+        ))
+
+
+def run(job=None, logger=None, **kwargs):
+    """
+    Create a cluster, poll until the IP address becomes available, and import
+    the cluster into CloudBolt.
+    """
+    environment = Environment.objects.get(id=ENV_ID)
+
+    # Save cluster data on the service so teardown works later
+    create_required_parameters()
+    service = kwargs['service']
+    service.create_gke_k8s_cluster_env = environment.id
+    service.name = CLUSTER_NAME
+    service.save()
+
+    job.set_progress('Connecting to GKE...')
+    builder = GKEClusterBuilder(environment, CLUSTER_NAME)
+
+    job.set_progress('Sending request for new cluster {}...'.format(CLUSTER_NAME))
+    builder.create_cluster(NODE_COUNT)
+    service.create_gke_k8s_cluster_name = CLUSTER_NAME
+
+    job.set_progress('Waiting up to {} seconds for provisioning to complete.'
+                     .format(TIMEOUT))
+    start = time.time()
+    job.set_progress('Waiting for cluster IP address...')
+    endpoint = builder.wait_for_endpoint(timeout=TIMEOUT)
+    if not endpoint:
+        return ("FAILURE",
+                "No IP address returned after {} seconds".format(TIMEOUT),
+                "")
+
+    remaining_time = TIMEOUT - (time.time() - start)
+    job.set_progress('Waiting for nodes to report hostnames...')
+    nodes = builder.wait_for_nodes(NODE_COUNT, timeout=remaining_time)
+    if len(nodes) < NODE_COUNT:
+        return ("FAILURE",
+                "Nodes are not ready after {} seconds".format(TIMEOUT),
+                "")
+
+    job.set_progress('Importing cluster...')
+    cluster = builder.get_cluster()
+    tech = ContainerOrchestratorTechnology.objects.get(name='Kubernetes')
+    kubernetes = Kubernetes.objects.create(
+        name=CLUSTER_NAME,
+        ip=cluster['endpoint'],
+        port=443,
+        protocol='https',
+        serviceaccount=cluster['masterAuth']['username'],
+        servicepasswd=cluster['masterAuth']['password'],
+        container_technology=tech,
+    )
+    service.create_gke_k8s_cluster_id = kubernetes.id
+    url = 'https://{}{}'.format(
+        PortalConfig.get_current_portal().domain,
+        reverse('container_orchestrator_detail', args=[kubernetes.id])
+    )
+    job.set_progress("Cluster URL: {}".format(url))
+
+    job.set_progress('Importing nodes...')
+    for node in nodes:
+        # Generate libcloud UUID from GCE ID
+        uuid = hashlib.sha1(b'%s:%s' % (node['id'], 'gce')).hexdigest()
+        # Create a barebones server record. Other details like CPU and Mem Size
+        # will be populated the next time the GCE handler is synced.
+        Server.objects.create(
+            hostname=node['name'],
+            resource_handler_svr_id=uuid,
+            environment=environment,
+            resource_handler=environment.resource_handler,
+            group=service.group,
+            owner=service.owner,
+        )
+
+    job.set_progress('Waiting for cluster to report as running...')
+    remaining_time = TIMEOUT - (time.time() - start)
+    status = builder.wait_for_running_status(timeout=remaining_time)
+    if status != 'RUNNING':
+        return ("FAILURE",
+                "Status is {} after {} seconds (expected RUNNING)".format(
+                    status, TIMEOUT),
+                "")
+
+    return ("SUCCESS",
+            "Cluster is ready and can be accessed at {}".format(url),
+            "")

--- a/blueprints/gke_cluster/delete_gke_cluster/delete_gke_cluster.json
+++ b/blueprints/gke_cluster/delete_gke_cluster/delete_gke_cluster.json
@@ -1,0 +1,10 @@
+{
+    "description": "",
+    "max-retries": 0,
+    "name": "Delete GKE Cluster",
+    "resource-technologies": [],
+    "script-filename": "cb_plugin_1512001080542294.py",
+    "shared": "False",
+    "target-os-families": [],
+    "type": "CloudBolt Plug-in"
+}

--- a/blueprints/gke_cluster/delete_gke_cluster/delete_gke_cluster.py
+++ b/blueprints/gke_cluster/delete_gke_cluster/delete_gke_cluster.py
@@ -1,0 +1,54 @@
+from __future__ import unicode_literals
+
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+from oauth2client.service_account import ServiceAccountCredentials
+
+from containerorchestrators.kuberneteshandler.models import Kubernetes
+from infrastructure.models import Environment
+
+
+def run(job=None, logger=None, service=None, **kwargs):
+    # Get cluster information
+    cluster_name = service.create_gke_k8s_cluster_name
+    if not cluster_name:
+        return "WARNING", "No cluster associated with this service", ""
+    env_id = service.create_gke_k8s_cluster_env
+    try:
+        environment = Environment.objects.get(id=env_id)
+    except Environment.DoesNotExist:
+        return ("FAILURE",
+                "The environment used to create this cluster no longer exists",
+                "")
+    handler = environment.resource_handler.cast()
+    project = handler.project
+    zone = environment.node_location
+
+    # Get client
+    credentials = ServiceAccountCredentials.from_json_keyfile_dict({
+        'client_email': handler.serviceaccount,
+        'private_key': handler.servicepasswd,
+        'type': 'service_account',
+        'client_id': None,
+        'private_key_id': None,
+    })
+    client = build('container', 'v1', credentials=credentials)
+    cluster_resource = client.projects().zones().clusters()
+
+    # Delete cluster
+    job.set_progress("Deleting cluster {}...".format(cluster_name))
+    try:
+        cluster_resource.delete(
+            projectId=project, zone=zone, clusterId=cluster_name).execute()
+    except HttpError as error:
+        if error.resp['status'] == '404':
+            return ("WARNING",
+                    "Cluster {} was not found. It may have already been "
+                    "deleted.".format(cluster_name),
+                    "")
+        raise
+
+    # In CB 7.6 and before, this will delete any existing KubernetesResources.
+    # Starting in CB 7.7, they will be marked HISTORICAL instead.
+    kubernetes = Kubernetes.objects.get(id=service.create_gke_k8s_cluster_id)
+    kubernetes.delete()

--- a/blueprints/gke_cluster/gke_cluster.json
+++ b/blueprints/gke_cluster/gke_cluster.json
@@ -1,0 +1,33 @@
+{
+    "any-group-can-deploy": true,
+    "build-items": [
+        {
+            "continue-on-failure": false,
+            "deploy-seq": 1,
+            "description": null,
+            "execute-in-parallel": false,
+            "id": "38",
+            "name": "Create GKE Cluster",
+            "run-on-scale-up": true,
+            "show-on-order-form": true,
+            "type": "plugin"
+        }
+    ],
+    "create-service": true,
+    "description": "Provisions a Kubernetes cluster into an existing Google Compute Engine environment using Google Kubernetes Engine. The cluster will be imported as a Container Orchestrator, and the nodes as Servers.",
+    "id": "20",
+    "is-orderable": true,
+    "name": "GKE Cluster",
+    "service-management-actions": [],
+    "teardown-items": [
+        {
+            "continue-on-failure": false,
+            "deploy-seq": -1,
+            "description": null,
+            "execute-in-parallel": false,
+            "id": "39",
+            "name": "Delete GKE Cluster",
+            "type": "teardown_plugin"
+        }
+    ]
+}


### PR DESCRIPTION
Adds a blueprint to provision a Kubernetes cluster in Google Kubernetes Engine.

Beyond creating the cluster, here are some additional features of the blueprint:

* The environment list is pulled from the existing GCE environments, so users don't need to manually enter info like credentials or project names.
* The cluster name and environment are stored as a parameter on the service, allowing us to decommission the cluster during service teardown.
* A container orchestrator is created using the IP address and credentials returned by 
* The container orchestrator's ID is stored on the service, and we delete it during service teardown.
    * Note: in 7.6 and before, deleting the container orchestrator deletes all its resources. Starting in 7.7, it does a soft delete to preserve history.
* Deleting a service where the cluster has already been deleted in GKE will result in a warning, which matches server decommissioning.

The file structure here matches the export format, so the folders can be zipped up and imported into a CB instance.