### PR TITLE
Create CB objects on Kube deployment

### DIFF
--- a/actions/cloudbolt_plugins/configure_nodes_for_rke/configure_nodes_for_rke.py
+++ b/actions/cloudbolt_plugins/configure_nodes_for_rke/configure_nodes_for_rke.py
@@ -269,8 +269,12 @@ def create_cb_objects(resource_id):
         "ca_file_contents": ca_cert,
         "container_technology": corch_technology,
     }
-    Kubernetes.objects.create(**kubernetes_data)
-    Environment.objects.create(name="Resource-{} Environment".format(resource_id), container_orchestrator=kube)
+    container_orchestrator = Kubernetes.objects.create(**kubernetes_data)
+    Environment.objects.create(name="Resource-{} Environment".format(resource_id), container_orchestrator=container_orchestrator)
+
+    resource = Resource.objects.get(id=resource_id)
+    resource.container_orchestrator_id = container_orchestrator.id
+    resource.save()
 
 
 def run(job, *_args, **kwargs):

--- a/actions/cloudbolt_plugins/configure_nodes_for_rke/configure_nodes_for_rke.py
+++ b/actions/cloudbolt_plugins/configure_nodes_for_rke/configure_nodes_for_rke.py
@@ -17,7 +17,7 @@ from utilities import run_command
 import settings
 
 # set this if `rke` is not in your PATH
-PATH_TO_RKE_EXECUTABLE = '/var/opt/cloudbolt/kubernetes/bin/rke'
+PATH_TO_RKE_EXECUTABLE = '/var/opt/cloudbolt/kubernetes/bin/kubernetes'
 logger = ThreadLogger(__name__)
 
 
@@ -269,8 +269,8 @@ def create_cb_objects(resource_id):
         "ca_file_contents": ca_cert,
         "container_technology": corch_technology,
     }
-    kube = Kubernetes.objects.create(**kubernetes_data)
-    env = Environment.objects.create(name="Resource-{} Environment".format(resource_id), container_orchestrator=kube)
+    Kubernetes.objects.create(**kubernetes_data)
+    Environment.objects.create(name="Resource-{} Environment".format(resource_id), container_orchestrator=kube)
 
 
 def run(job, *_args, **kwargs):
@@ -311,4 +311,4 @@ def run(job, *_args, **kwargs):
     set_progress(f"Creating CB objects...")
     create_cb_objects(resource_id)
 
-    return "SUCCESS", f"./rke up --config={cluster_path}/cluster.yml", ""
+    return "SUCCESS", f"./kubernetes up --config={cluster_path}/cluster.yml", ""

--- a/actions/cloudbolt_plugins/configure_nodes_for_rke/configure_nodes_for_rke.py
+++ b/actions/cloudbolt_plugins/configure_nodes_for_rke/configure_nodes_for_rke.py
@@ -10,6 +10,7 @@ from common.methods import set_progress
 from containerorchestrators.models import ContainerOrchestratorTechnology
 from containerorchestrators.kuberneteshandler.models import Kubernetes
 from infrastructure.models import Environment
+from resource.models import Resource
 from utilities.exceptions import CommandExecutionException
 from utilities.logger import ThreadLogger
 from utilities import run_command


### PR DESCRIPTION
To supplement the deployment of a Kubernetes cluster accomplished by this Plug-in, we also create the associated Environment and ContainerOrchestrator objects in CloudBolt, so that the cluster can be managed and interacted with from within CloudBolt.

[DEV-13553]

[DEV-13553]: https://cloudbolt.atlassian.net/browse/DEV-13553