### PR TITLE
Set multi-node kube blueprint to resource type "kubernetes_cluster"

### DIFF
--- a/blueprints/multi_node_kubernetes_cluster/kube_multi_node.json
+++ b/blueprints/multi_node_kubernetes_cluster/kube_multi_node.json
@@ -58,11 +58,11 @@
         }
     ],
     "resource-type": {
-        "icon": "",
-        "label": "Service",
+        "icon": "fas fa-dharmachakra",
+        "label": "Kubernetes Cluster",
         "lifecycle": "ACTIVE",
         "list-view-columns": [],
-        "name": "service",
+        "name": "kubernetes_cluster",
         "plural-label": null
     },
     "sequence": 0,


### PR DESCRIPTION
We have some logic coming in 9.2 that expects this blueprint to deploy a resource of type "kubernetes_cluster" not "service".