### PR TITLE
Use Tech Wrapper for auth on Azure - remove ad-hoc ServicePrincipalCredentials DEV-14550

### DIFF
--- a/blueprints/azure_web_app/azure_web_app_syncronization.py
+++ b/blueprints/azure_web_app/azure_web_app_syncronization.py
@@ -1,37 +1,11 @@
-"""
-This plugin is to synchronize Azure Web App resources
-
-It should be placed in Orchestration Actions at the
-Post Sync VMs Hookpoint.
-
-Additionally, this action should have its Resource Technology limited to Azure
-
-"""
-if __name__ == "__main__":
-    import os
-    import sys
-    import django
-
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
-    sys.path.append("/opt/cloudbolt")
-    django.setup()
-
 from common.methods import set_progress
-from infrastructure.models import CustomField
-from jobs.models import Job
-from resourcehandlers.azure_arm.models import AzureARMHandler
+
 from azure.common.credentials import ServicePrincipalCredentials
 from azure.mgmt.resource import ResourceManagementClient
 from azure.mgmt.web import WebSiteManagementClient
+from resourcehandlers.azure_arm.models import AzureARMHandler
 
-from resources.models import ResourceType, Resource
-from servicecatalog.models import ServiceBlueprint
-from accounts.models import Group
-
-from utilities.logger import ThreadLogger
-
-
-logger = ThreadLogger(__name__)
+RESOURCE_IDENTIFIER = "azure_web_app_id"
 
 
 def _get_clients(handler):
@@ -70,117 +44,25 @@ def _get_clients(handler):
     return web_client, resource_client
 
 
-def run(job, **kwargs):
-    # Connect to Azure Management Service
-    azure = AzureARMHandler.objects.first()
-    web_client, resource_client = _get_clients(azure)
+def discover_resources(**kwargs):
+    discovered_web_apps = []
+    for handler in AzureARMHandler.objects.all():
 
-    # Generate custom fields
-    CustomField.objects.get_or_create(
-        name="web_app_id",
-        label="Azure Web App ID",
-        type="STR",
-        description="Used by the Azure Web App resource & blueprint.",
-    )
+        web_client, resource_client = _get_clients(handler)
 
-    # Generate custom fields
-    CustomField.objects.get_or_create(
-        name="web_app_location",
-        label="Azure Web App Location",
-        type="STR",
-        description="Used by the Azure Web App resource & blueprint.",
-    )
-
-    # Generate custom fields
-    CustomField.objects.get_or_create(
-        name="web_app_default_host_name",
-        label="Azure Web App Host Name",
-        type="URL",
-        description="Used by the Azure Web App resource & blueprint.",
-    )
-
-    # Generate custom fields
-    # CustomField.objects.get_or_create(
-    #    name='resource_group_name', label='Azure Web App Host Name', type='STR',
-    #    description='Resource Group Name.'
-    # )
-
-    # Get the 'Azure Web App' blueprint
-    bp = ServiceBlueprint.objects.get(id=6)
-
-    # Just use a specific group for now
-    group = Group.objects.get(id=2)
-
-    # Make Discovered Azure Web Apps CloudBolt Resource Types. 'Web Apps'
-    rt = ResourceType.objects.get(name="web_apps")
-
-    # Get existing (Active) Web Apps Resources from CloudBolt
-    cb_web_apps = Resource.objects.filter(
-        resource_type__name="web_apps", lifecycle="ACTIVE"
-    )
-    cb_app_ids = []
-    for app in cb_web_apps:
-        cb_app_ids.append(app.web_app_id)
-
-    # Discover Resource Groups with Web Apps
-    set_progress("Getting List of Web Apps by Resource Groups")
-
-    for groups in resource_client.resource_groups.list():
-        web_apps = web_client.web_apps.list_by_resource_group(
-            resource_group_name=groups.name
-        )
-        web_app_ids = []
-        for web_app in web_apps:
-            # Skip creation if Web App already exists
-            if web_app.id in cb_app_ids:
-                set_progress(
-                    "Web App: '{}' already exists in CloudBolt. Skipping...".format(
-                        web_app.name
-                    )
+        for groups in resource_client.resource_groups.list():
+            for web_app in web_client.web_apps.list_by_resource_group(
+                resource_group_name=groups.name
+            ):
+                discovered_web_apps.append(
+                    {
+                        "name": web_app.name,
+                        "azure_web_app_id": web_app.id,
+                        "azure_web_app_name": web_app.name,
+                        "azure_location": web_app.location,
+                        "azure_web_app_default_host_name": web_app.default_host_name,
+                        "resource_group_name": web_app.resource_group,
+                    }
                 )
-                web_app_ids.append(web_app.id)
-                continue
-            # Create the Resource in CloudBolt
-            set_progress("Creating Resource in CloudBolt for {}".format(web_app.name))
-            r = Resource(
-                name=web_app.name,
-                resource_type=rt,
-                lifecycle="ACTIVE",
-                blueprint=bp,
-                group=group,
-            )
-            r.save()
-            # Store Web App metadata on the resource as parameters for teardown
-            r.set_value_for_custom_field(cf_name="web_app_id", value=web_app.id)
-            r.set_value_for_custom_field(
-                cf_name="web_app_location", value=web_app.location
-            )
-            r.set_value_for_custom_field(
-                cf_name="web_app_default_host_name", value=web_app.default_host_name
-            )
-            r.set_value_for_custom_field(
-                cf_name="resource_group_name", value=web_app.resource_group
-            )
 
-            web_app_ids.append(web_app.id)
-
-        # Remove Web Apps that no longer exist
-        cb_apps_in_group = []
-        for app in cb_web_apps:
-            if app.resource_group_name == groups.name:
-                cb_apps_in_group.append(app)
-        for app in cb_apps_in_group:
-            if app.web_app_id not in web_app_ids:
-                set_progress(
-                    "Web App: '{}' no longer exists. Removing from CloudBolt...".format(
-                        app
-                    )
-                )
-                delete = app.available_actions()[0]["action"]
-                delete.run_hook_as_job(resources=[app])
-
-
-if __name__ == "__main__":
-    job_id = sys.argv[1]
-    job = Job.objects.get(id=job_id)
-    run = run(job)
+    return discovered_web_apps

--- a/blueprints/azure_web_app/azure_web_app_syncronization.py
+++ b/blueprints/azure_web_app/azure_web_app_syncronization.py
@@ -18,7 +18,6 @@ if __name__ == '__main__':
 from common.methods import set_progress
 from infrastructure.models import CustomField
 from jobs.models import Job
-from azure.common.credentials import ServicePrincipalCredentials
 from azure.mgmt.resource import ResourceManagementClient
 from azure.mgmt.web import WebSiteManagementClient
 from resourcehandlers.azure_arm.models import AzureARMHandler
@@ -34,12 +33,11 @@ def run(job, **kwargs):
     # Connect to Azure Management Service
     set_progress("Connecting To Azure Management Service...")
     azure = AzureARMHandler.objects.first()
+
     subscription_id = azure.serviceaccount
-    credentials = ServicePrincipalCredentials(
-        client_id=azure.client_id,
-        secret=azure.secret,
-        tenant=azure.tenant_id
-    )
+    wrapper = azure.get_api_wrapper()
+    credentials = wrapper.credentials
+
     client = ResourceManagementClient(credentials, subscription_id)
     web_client = WebSiteManagementClient(credentials, subscription_id)
     set_progress("Successfully Connected To Azure Management Service!")

--- a/blueprints/azure_web_app/azure_web_app_syncronization.py
+++ b/blueprints/azure_web_app/azure_web_app_syncronization.py
@@ -7,14 +7,15 @@ Post Sync VMs Hookpoint.
 Additionally, this action should have its Resource Technology limited to Azure
 
 """
-if __name__ == '__main__':
+if __name__ == "__main__":
     import os
     import sys
     import django
+
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
-    sys.path.append('/opt/cloudbolt')
+    sys.path.append("/opt/cloudbolt")
     django.setup()
-    
+
 from common.methods import set_progress
 from infrastructure.models import CustomField
 from jobs.models import Job
@@ -28,7 +29,9 @@ from accounts.models import Group
 
 from utilities.logger import ThreadLogger
 
+
 logger = ThreadLogger(__name__)
+
 
 def run(job, **kwargs):
     # Connect to Azure Management Service
@@ -39,70 +42,96 @@ def run(job, **kwargs):
     resource_client = wrapper.resource_client
     web_client = configure_arm_client(wrapper, WebSiteManagementClient)
     set_progress("Successfully Connected To Azure Management Service!")
-    
+
     # Generate custom fields
     CustomField.objects.get_or_create(
-        name='web_app_id', label='Azure Web App ID', type='STR',
-        description='Used by the Azure Web App resource & blueprint.'
+        name="web_app_id",
+        label="Azure Web App ID",
+        type="STR",
+        description="Used by the Azure Web App resource & blueprint.",
     )
-    
+
     # Generate custom fields
     CustomField.objects.get_or_create(
-        name='web_app_location', label='Azure Web App Location', type='STR',
-        description='Used by the Azure Web App resource & blueprint.'
+        name="web_app_location",
+        label="Azure Web App Location",
+        type="STR",
+        description="Used by the Azure Web App resource & blueprint.",
     )
-    
+
     # Generate custom fields
     CustomField.objects.get_or_create(
-        name='web_app_default_host_name', label='Azure Web App Host Name', type='URL',
-        description='Used by the Azure Web App resource & blueprint.'
+        name="web_app_default_host_name",
+        label="Azure Web App Host Name",
+        type="URL",
+        description="Used by the Azure Web App resource & blueprint.",
     )
-    
+
     # Generate custom fields
-    #CustomField.objects.get_or_create(
+    # CustomField.objects.get_or_create(
     #    name='resource_group_name', label='Azure Web App Host Name', type='STR',
     #    description='Resource Group Name.'
-    #)
-    
+    # )
+
     # Get the 'Azure Web App' blueprint
     bp = ServiceBlueprint.objects.get(id=6)
-    
+
     # Just use a specific group for now
     group = Group.objects.get(id=2)
-    
+
     # Make Discovered Azure Web Apps CloudBolt Resource Types. 'Web Apps'
-    rt = ResourceType.objects.get(name='web_apps')
-    
+    rt = ResourceType.objects.get(name="web_apps")
+
     # Get existing (Active) Web Apps Resources from CloudBolt
-    cb_web_apps = Resource.objects.filter(resource_type__name='web_apps', lifecycle='ACTIVE')
+    cb_web_apps = Resource.objects.filter(
+        resource_type__name="web_apps", lifecycle="ACTIVE"
+    )
     cb_app_ids = []
     for app in cb_web_apps:
         cb_app_ids.append(app.web_app_id)
-    
+
     # Discover Resource Groups with Web Apps
     set_progress("Getting List of Web Apps by Resource Groups")
-    
+
     for groups in resource_client.resource_groups.list():
-        web_apps = web_client.web_apps.list_by_resource_group(resource_group_name=groups.name)
+        web_apps = web_client.web_apps.list_by_resource_group(
+            resource_group_name=groups.name
+        )
         web_app_ids = []
         for web_app in web_apps:
             # Skip creation if Web App already exists
             if web_app.id in cb_app_ids:
-                set_progress("Web App: '{}' already exists in CloudBolt. Skipping...".format(web_app.name))
+                set_progress(
+                    "Web App: '{}' already exists in CloudBolt. Skipping...".format(
+                        web_app.name
+                    )
+                )
                 web_app_ids.append(web_app.id)
                 continue
             # Create the Resource in CloudBolt
-            set_progress('Creating Resource in CloudBolt for {}'.format(web_app.name))
-            r = Resource(name=web_app.name, resource_type=rt, lifecycle='ACTIVE', blueprint=bp, group=group)
+            set_progress("Creating Resource in CloudBolt for {}".format(web_app.name))
+            r = Resource(
+                name=web_app.name,
+                resource_type=rt,
+                lifecycle="ACTIVE",
+                blueprint=bp,
+                group=group,
+            )
             r.save()
             # Store Web App metadata on the resource as parameters for teardown
-            r.set_value_for_custom_field(cf_name='web_app_id', value=web_app.id)
-            r.set_value_for_custom_field(cf_name='web_app_location', value=web_app.location)
-            r.set_value_for_custom_field(cf_name='web_app_default_host_name', value=web_app.default_host_name)
-            r.set_value_for_custom_field(cf_name='resource_group_name', value=web_app.resource_group)
-            
+            r.set_value_for_custom_field(cf_name="web_app_id", value=web_app.id)
+            r.set_value_for_custom_field(
+                cf_name="web_app_location", value=web_app.location
+            )
+            r.set_value_for_custom_field(
+                cf_name="web_app_default_host_name", value=web_app.default_host_name
+            )
+            r.set_value_for_custom_field(
+                cf_name="resource_group_name", value=web_app.resource_group
+            )
+
             web_app_ids.append(web_app.id)
-        
+
         # Remove Web Apps that no longer exist
         cb_apps_in_group = []
         for app in cb_web_apps:
@@ -110,12 +139,16 @@ def run(job, **kwargs):
                 cb_apps_in_group.append(app)
         for app in cb_apps_in_group:
             if app.web_app_id not in web_app_ids:
-                set_progress("Web App: '{}' no longer exists. Removing from CloudBolt...".format(app))
-                delete = app.available_actions()[0]['action']
+                set_progress(
+                    "Web App: '{}' no longer exists. Removing from CloudBolt...".format(
+                        app
+                    )
+                )
+                delete = app.available_actions()[0]["action"]
                 delete.run_hook_as_job(resources=[app])
-        
-        
-if __name__ == '__main__':
+
+
+if __name__ == "__main__":
     job_id = sys.argv[1]
     job = Job.objects.get(id=job_id)
     run = run(job)

--- a/blueprints/azure_web_app/create_azure_website_wVVuKFC.py
+++ b/blueprints/azure_web_app/create_azure_website_wVVuKFC.py
@@ -9,6 +9,7 @@ from infrastructure.models import CustomField
 from azure.mgmt.web import WebSiteManagementClient
 from resourcehandlers.azure_arm.models import AzureARMHandler
 from azure.mgmt.web.models import AppServicePlan, SkuDescription, Site
+from resourcehandlers.azure_arm.azure_wrapper import configure_arm_client
 
 
 def generate_options_for_resource_groups(server=None, **kwargs):
@@ -25,10 +26,9 @@ def generate_options_for_service_plans(server=None, form_prefix=None, form_data=
     results = []
 
     azure = AzureARMHandler.objects.first()
-    subscription_id = azure.serviceaccount
-    credentials = azure.get_api_wrapper().credentials
+    wrapper = azure.get_api_wrapper()
+    web_client = configure_arm_client(wrapper, WebSiteManagementClient)
 
-    web_client = WebSiteManagementClient(credentials, subscription_id)
     service_plan = CustomField.objects.filter(name__contains='service_plan').first()
     resource_group = None
 
@@ -57,10 +57,9 @@ def run(job, **kwargs):
     # Connect to Azure Management Service
     set_progress("Connecting To Azure Management Service...")
     azure = AzureARMHandler.objects.first()
-    subscription_id = azure.serviceaccount
-    credentials = azure.get_api_wrapper().credentials
 
-    web_client = WebSiteManagementClient(credentials, subscription_id)
+    wrapper = azure.get_api_wrapper()
+    web_client = configure_arm_client(wrapper, WebSiteManagementClient)
     set_progress("Successfully Connected To Azure Management Service!")
 
     # Create Resource Group if Needed

--- a/blueprints/azure_web_app/create_azure_website_wVVuKFC.py
+++ b/blueprints/azure_web_app/create_azure_website_wVVuKFC.py
@@ -9,7 +9,41 @@ from infrastructure.models import CustomField
 from azure.mgmt.web import WebSiteManagementClient
 from resourcehandlers.azure_arm.models import AzureARMHandler
 from azure.mgmt.web.models import AppServicePlan, SkuDescription, Site
-from resourcehandlers.azure_arm.azure_wrapper import configure_arm_client
+from azure.common.credentials import ServicePrincipalCredentials
+
+
+def _get_client(handler):
+    """
+    Get the clients using newer methods from the CloudBolt main repo if this CB is running
+    a version greater than 9.2. These internal methods implicitly take care of much of the other
+    features in CloudBolt such as proxy and ssl verification.
+    Otherwise, manually instantiate clients without support for those other CloudBolt settings.
+    :param handler:
+    :return:
+    """
+    import settings
+    from common.methods import is_version_newer
+
+    set_progress("Connecting To Azure...")
+
+    cb_version = settings.VERSION_INFO["VERSION"]
+    if is_version_newer(cb_version, "9.2"):
+        from resourcehandlers.azure_arm.azure_wrapper import configure_arm_client
+
+        wrapper = handler.get_api_wrapper()
+        web_client = configure_arm_client(wrapper, WebSiteManagementClient)
+    else:
+        # TODO: Remove once versions <= 9.2 are no longer supported.
+        credentials = ServicePrincipalCredentials(
+            client_id=handler.client_id,
+            secret=handler.secret,
+            tenant=handler.tenant_id,
+        )
+        web_client = WebSiteManagementClient(credentials, handler.serviceaccount)
+
+    set_progress("Connection to Azure established")
+
+    return web_client
 
 
 def generate_options_for_resource_groups(server=None, **kwargs):
@@ -22,14 +56,15 @@ def generate_options_for_resource_groups(server=None, **kwargs):
     return resource_group
 
 
-def generate_options_for_service_plans(server=None, form_prefix=None, form_data=None, **kwargs):
+def generate_options_for_service_plans(
+    server=None, form_prefix=None, form_data=None, **kwargs
+):
     results = []
 
     azure = AzureARMHandler.objects.first()
-    wrapper = azure.get_api_wrapper()
-    web_client = configure_arm_client(wrapper, WebSiteManagementClient)
+    web_client = _get_client(azure)
 
-    service_plan = CustomField.objects.filter(name__contains='service_plan').first()
+    service_plan = CustomField.objects.filter(name__contains="service_plan").first()
     resource_group = None
 
     if service_plan:
@@ -38,13 +73,15 @@ def generate_options_for_service_plans(server=None, form_prefix=None, form_data=
         if control:
             keys = control.keys()
             for k in keys:
-                if 'resource_group' in k:
+                if "resource_group" in k:
                     # Extract from the control data structure, ex: {'resource_group_a123': ['rgName']}
                     resource_group = control[k][0]
 
     if resource_group:
         try:
-            for sp in web_client.app_service_plans.list_by_resource_group(resource_group_name=resource_group):
+            for sp in web_client.app_service_plans.list_by_resource_group(
+                resource_group_name=resource_group
+            ):
                 results.append(sp.name)
         except:
             pass
@@ -52,36 +89,37 @@ def generate_options_for_service_plans(server=None, form_prefix=None, form_data=
 
 
 def run(job, **kwargs):
-    resource = kwargs.get('resource')
+    resource = kwargs.get("resource")
 
     # Connect to Azure Management Service
-    set_progress("Connecting To Azure Management Service...")
     azure = AzureARMHandler.objects.first()
-
-    wrapper = azure.get_api_wrapper()
-    web_client = configure_arm_client(wrapper, WebSiteManagementClient)
-    set_progress("Successfully Connected To Azure Management Service!")
+    web_client = _get_client(azure)
 
     # Create Resource Group if Needed
-    resource_group = '{{ resource_groups }}'
+    resource_group = "{{ resource_groups }}"
 
     # Create App Service Plan if Needed
-    service_plan = '{{ service_plans }}'
-    service_plan_obj = web_client.app_service_plans.get(resource_group_name=resource_group, name=service_plan)
+    service_plan = "{{ service_plans }}"
+    service_plan_obj = web_client.app_service_plans.get(
+        resource_group_name=resource_group, name=service_plan
+    )
 
     # Create Web App
     site_async_operation = web_client.web_apps.create_or_update(
         resource_group,
         resource.name,
-        Site(
-            location=service_plan_obj.location,
-            server_farm_id=service_plan_obj.id
-        )
+        Site(location=service_plan_obj.location, server_farm_id=service_plan_obj.id),
     )
     site = site_async_operation.result()
 
     # Store Web App metadata on the resource as parameters for teardown
-    resource.set_value_for_custom_field(cf_name='web_app_id', value=site.id)
-    resource.set_value_for_custom_field(cf_name='resource_group_name', value=resource_group)
-    resource.set_value_for_custom_field(cf_name='web_app_location', value=service_plan_obj.location)
-    resource.set_value_for_custom_field(cf_name='web_app_default_host_name', value=site.default_host_name)
+    resource.set_value_for_custom_field(cf_name="web_app_id", value=site.id)
+    resource.set_value_for_custom_field(
+        cf_name="resource_group_name", value=resource_group
+    )
+    resource.set_value_for_custom_field(
+        cf_name="web_app_location", value=service_plan_obj.location
+    )
+    resource.set_value_for_custom_field(
+        cf_name="web_app_default_host_name", value=site.default_host_name
+    )

--- a/blueprints/azure_web_app/delete_azure_web_app.py
+++ b/blueprints/azure_web_app/delete_azure_web_app.py
@@ -4,7 +4,41 @@ Deletes Web App from Azure
 from azure.mgmt.web import WebSiteManagementClient
 from common.methods import set_progress
 from resourcehandlers.azure_arm.models import AzureARMHandler
-from resourcehandlers.azure_arm.azure_wrapper import configure_arm_client
+from azure.common.credentials import ServicePrincipalCredentials
+
+
+def _get_client(handler):
+    """
+    Get the clients using newer methods from the CloudBolt main repo if this CB is running
+    a version greater than 9.2. These internal methods implicitly take care of much of the other
+    features in CloudBolt such as proxy and ssl verification.
+    Otherwise, manually instantiate clients without support for those other CloudBolt settings.
+    :param handler:
+    :return:
+    """
+    import settings
+    from common.methods import is_version_newer
+
+    set_progress("Connecting To Azure...")
+
+    cb_version = settings.VERSION_INFO["VERSION"]
+    if is_version_newer(cb_version, "9.2"):
+        from resourcehandlers.azure_arm.azure_wrapper import configure_arm_client
+
+        wrapper = handler.get_api_wrapper()
+        web_client = configure_arm_client(wrapper, WebSiteManagementClient)
+    else:
+        # TODO: Remove once versions <= 9.2 are no longer supported.
+        credentials = ServicePrincipalCredentials(
+            client_id=handler.client_id,
+            secret=handler.secret,
+            tenant=handler.tenant_id,
+        )
+        web_client = WebSiteManagementClient(credentials, handler.serviceaccount)
+
+    set_progress("Connection to Azure established")
+
+    return web_client
 
 
 def run(job, **kwargs):
@@ -12,14 +46,11 @@ def run(job, **kwargs):
     resource = job.resource_set.first()
 
     # Connect to Azure Management Service
-    set_progress("Connecting To Azure Management Service...")
     azure = AzureARMHandler.objects.first()
-    wrapper = azure.get_api_wrapper()
-    web_client = configure_arm_client(wrapper, WebSiteManagementClient)
-    set_progress("Successfully Connected To Azure Management Service!")
+    web_client = _get_client(azure)
 
     # Use custom field web_app_id to get web app from Azure
-    rg = resource.attributes.get(field__name__startswith='resource_group_name')
+    rg = resource.attributes.get(field__name__startswith="resource_group_name")
 
     # Delete the web app
     web_client.web_apps.delete(resource_group_name=rg.value, name=resource.name)

--- a/blueprints/azure_web_app/delete_azure_web_app.py
+++ b/blueprints/azure_web_app/delete_azure_web_app.py
@@ -4,6 +4,7 @@ Deletes Web App from Azure
 from azure.mgmt.web import WebSiteManagementClient
 from common.methods import set_progress
 from resourcehandlers.azure_arm.models import AzureARMHandler
+from resourcehandlers.azure_arm.azure_wrapper import configure_arm_client
 
 
 def run(job, **kwargs):
@@ -13,10 +14,8 @@ def run(job, **kwargs):
     # Connect to Azure Management Service
     set_progress("Connecting To Azure Management Service...")
     azure = AzureARMHandler.objects.first()
-    subscription_id = azure.serviceaccount
-    credentials = azure.get_api_wrapper().credentials
-
-    web_client = WebSiteManagementClient(credentials, subscription_id)
+    wrapper = azure.get_api_wrapper()
+    web_client = configure_arm_client(wrapper, WebSiteManagementClient)
     set_progress("Successfully Connected To Azure Management Service!")
 
     # Use custom field web_app_id to get web app from Azure

--- a/blueprints/azure_web_app/delete_azure_web_app.py
+++ b/blueprints/azure_web_app/delete_azure_web_app.py
@@ -1,10 +1,10 @@
 """
 Deletes Web App from Azure
 """
+from azure.common.credentials import ServicePrincipalCredentials
 from azure.mgmt.web import WebSiteManagementClient
 from common.methods import set_progress
 from resourcehandlers.azure_arm.models import AzureARMHandler
-from azure.common.credentials import ServicePrincipalCredentials
 
 
 def _get_client(handler):
@@ -46,11 +46,14 @@ def run(job, **kwargs):
     resource = job.resource_set.first()
 
     # Connect to Azure Management Service
-    azure = AzureARMHandler.objects.first()
-    web_client = _get_client(azure)
+    set_progress("Connecting To Azure Management Service...")
+    handler = AzureARMHandler.objects.first()
+    web_client = _get_client(handler)
 
     # Use custom field web_app_id to get web app from Azure
     rg = resource.attributes.get(field__name__startswith="resource_group_name")
 
     # Delete the web app
-    web_client.web_apps.delete(resource_group_name=rg.value, name=resource.name)
+    web_client.web_apps.delete(
+        resource_group_name=rg.value, name=resource.name, delete_empty_server_farm=False
+    )

--- a/blueprints/azure_web_app/delete_azure_web_app.py
+++ b/blueprints/azure_web_app/delete_azure_web_app.py
@@ -1,13 +1,10 @@
 """
 Deletes Web App from Azure
 """
-from azure.common.credentials import ServicePrincipalCredentials
 from azure.mgmt.web import WebSiteManagementClient
 from common.methods import set_progress
-from infrastructure.models import CustomField
-from jobs.models import Job
 from resourcehandlers.azure_arm.models import AzureARMHandler
-from resources.models import ResourceType, Resource
+
 
 def run(job, **kwargs):
     # Run as Resource teardown management command
@@ -17,11 +14,8 @@ def run(job, **kwargs):
     set_progress("Connecting To Azure Management Service...")
     azure = AzureARMHandler.objects.first()
     subscription_id = azure.serviceaccount
-    credentials = ServicePrincipalCredentials(
-        client_id=azure.client_id,
-        secret=azure.secret,
-        tenant=azure.tenant_id
-    )
+    credentials = azure.get_api_wrapper().credentials
+
     web_client = WebSiteManagementClient(credentials, subscription_id)
     set_progress("Successfully Connected To Azure Management Service!")
 

--- a/blueprints/azure_web_app/restart_azure_web_app.py
+++ b/blueprints/azure_web_app/restart_azure_web_app.py
@@ -2,13 +2,9 @@
 Restart Azure Web App
 """
 from common.methods import set_progress
-from infrastructure.models import CustomField
-from azure.common.credentials import ServicePrincipalCredentials
-from azure.mgmt.resource import ResourceManagementClient
 from azure.mgmt.web import WebSiteManagementClient
 from resourcehandlers.azure_arm.models import AzureARMHandler
-from azure.mgmt.web.models import AppServicePlan, SkuDescription, Site
-from resources.models import ResourceType, Resource
+
 
 def run(job, **kwargs):
     resource = kwargs.get('resource')
@@ -17,11 +13,7 @@ def run(job, **kwargs):
     set_progress("Connecting To Azure Management Service...")
     azure = AzureARMHandler.objects.first()
     subscription_id = azure.serviceaccount
-    credentials = ServicePrincipalCredentials(
-        client_id=azure.client_id,
-        secret=azure.secret,
-        tenant=azure.tenant_id
-    )
+    credentials = azure.get_api_wrapper().credentials
     web_client = WebSiteManagementClient(credentials, subscription_id)
     set_progress("Successfully Connected To Azure Management Service!")
 

--- a/blueprints/azure_web_app/restart_azure_web_app.py
+++ b/blueprints/azure_web_app/restart_azure_web_app.py
@@ -2,9 +2,9 @@
 Restart Azure Web App
 """
 from common.methods import set_progress
+from azure.common.credentials import ServicePrincipalCredentials
 from azure.mgmt.web import WebSiteManagementClient
 from resourcehandlers.azure_arm.models import AzureARMHandler
-from azure.common.credentials import ServicePrincipalCredentials
 
 
 def _get_client(handler):
@@ -45,8 +45,11 @@ def run(job, **kwargs):
     resource = kwargs.get('resource')
 
     # Connect to Azure Management Service
-    azure = AzureARMHandler.objects.first()
-    web_client = _get_client(azure)
+    set_progress("Connecting To Azure Management Service...")
+    handler = AzureARMHandler.objects.first()
+
+    web_client = _get_client(handler)
+    set_progress("Successfully Connected To Azure Management Service!")
 
     # Restart Web App
     web_client.web_apps.restart(resource_group_name=resource.resource_group_name, name=resource.name)

--- a/blueprints/azure_web_app/restart_azure_web_app.py
+++ b/blueprints/azure_web_app/restart_azure_web_app.py
@@ -4,6 +4,7 @@ Restart Azure Web App
 from common.methods import set_progress
 from azure.mgmt.web import WebSiteManagementClient
 from resourcehandlers.azure_arm.models import AzureARMHandler
+from resourcehandlers.azure_arm.azure_wrapper import configure_arm_client
 
 
 def run(job, **kwargs):
@@ -12,9 +13,8 @@ def run(job, **kwargs):
     # Connect to Azure Management Service
     set_progress("Connecting To Azure Management Service...")
     azure = AzureARMHandler.objects.first()
-    subscription_id = azure.serviceaccount
-    credentials = azure.get_api_wrapper().credentials
-    web_client = WebSiteManagementClient(credentials, subscription_id)
+    wrapper = azure.get_api_wrapper()
+    web_client = configure_arm_client(wrapper, WebSiteManagementClient)
     set_progress("Successfully Connected To Azure Management Service!")
 
     # Restart Web App

--- a/blueprints/azure_web_app/restart_azure_web_app.py
+++ b/blueprints/azure_web_app/restart_azure_web_app.py
@@ -4,18 +4,49 @@ Restart Azure Web App
 from common.methods import set_progress
 from azure.mgmt.web import WebSiteManagementClient
 from resourcehandlers.azure_arm.models import AzureARMHandler
-from resourcehandlers.azure_arm.azure_wrapper import configure_arm_client
+from azure.common.credentials import ServicePrincipalCredentials
+
+
+def _get_client(handler):
+    """
+    Get the clients using newer methods from the CloudBolt main repo if this CB is running
+    a version greater than 9.2. These internal methods implicitly take care of much of the other
+    features in CloudBolt such as proxy and ssl verification.
+    Otherwise, manually instantiate clients without support for those other CloudBolt settings.
+    :param handler:
+    :return:
+    """
+    import settings
+    from common.methods import is_version_newer
+
+    set_progress("Connecting To Azure...")
+
+    cb_version = settings.VERSION_INFO["VERSION"]
+    if is_version_newer(cb_version, "9.2"):
+        from resourcehandlers.azure_arm.azure_wrapper import configure_arm_client
+
+        wrapper = handler.get_api_wrapper()
+        web_client = configure_arm_client(wrapper, WebSiteManagementClient)
+    else:
+        # TODO: Remove once versions <= 9.2 are no longer supported.
+        credentials = ServicePrincipalCredentials(
+            client_id=handler.client_id,
+            secret=handler.secret,
+            tenant=handler.tenant_id,
+        )
+        web_client = WebSiteManagementClient(credentials, handler.serviceaccount)
+
+    set_progress("Connection to Azure established")
+
+    return web_client
 
 
 def run(job, **kwargs):
     resource = kwargs.get('resource')
 
     # Connect to Azure Management Service
-    set_progress("Connecting To Azure Management Service...")
     azure = AzureARMHandler.objects.first()
-    wrapper = azure.get_api_wrapper()
-    web_client = configure_arm_client(wrapper, WebSiteManagementClient)
-    set_progress("Successfully Connected To Azure Management Service!")
+    web_client = _get_client(azure)
 
     # Restart Web App
     web_client.web_apps.restart(resource_group_name=resource.resource_group_name, name=resource.name)


### PR DESCRIPTION
…et_api_wrapper

* 

[DEV-14550]

# Development Prerequisites
- **Developer:** @gsimore 
- **Partner:** @pop 
- **Jira Story:** [DEV-14550](https://cloudbolt.atlassian.net/browse/DEV-14550)
- **Design Doc:** N/A

## Summary of Proposed Changes
* Use Tech Wrapper for auth on Azure - remove ad-hoc ServicePrincipalCredentials because this is best practice in the code; reusing our existing authentication for the wrapper to get credentials so that all of the details are covered, and this is needed for SSL and Proxy support in Azure blueprints.
* Also use the new public 'configure_arm_client' method when configuring new clients that are not included in the tech wrapper. 

[DEV-14550]: https://cloudbolt.atlassian.net/browse/DEV-14550