### PR TITLE
Added a sample recurring job to delete stale zip files from CB /tmp/S…

### DIFF
--- a/actions/cloudbolt_plugins/recurring_jobs/remove_.zip_from_tmp.py
+++ b/actions/cloudbolt_plugins/recurring_jobs/remove_.zip_from_tmp.py
@@ -4,13 +4,14 @@ This action removes all the zip files from CloudBolt /tmp/systemd-private* direc
 from common.methods import set_progress
 import glob
 import os
+import time
 
 def run(job, *args, **kwargs):
     
     zip_file_list = glob.glob("/tmp/systemd-private*/tmp/*.zip")
     set_progress("Found following zip files in /tmp: {}".format(zip_file_list))
     for file in zip_file_list:
-        set_progress("Removing these files {}".format(file))
-        os.remove(file)
-
+        if os.path.getmtime(file) < time.time() - 5 * 60:
+	   set_progress("Removing these files {}".format(file))
+           os.remove(file)
     return "SUCCESS", "", ""

--- a/actions/cloudbolt_plugins/recurring_jobs/remove_.zip_from_tmp.py
+++ b/actions/cloudbolt_plugins/recurring_jobs/remove_.zip_from_tmp.py
@@ -9,7 +9,7 @@ import time
 def run(job, *args, **kwargs):
     
     zip_file_list = glob.glob("/tmp/systemd-private*/tmp/*.zip")
-    set_progress("Found following zip files in /tmp: {}".format(zip_file_list))
+    set_progress("Found following zip files in /tmp/systemd/*/tmp: {}".format(zip_file_list))
     for file in zip_file_list:
         if os.path.getmtime(file) < time.time() - 5 * 60:
 	   set_progress("Removing these files {}".format(file))

--- a/actions/cloudbolt_plugins/recurring_jobs/remove_.zip_from_tmp.py
+++ b/actions/cloudbolt_plugins/recurring_jobs/remove_.zip_from_tmp.py
@@ -1,0 +1,16 @@
+"""
+This action removes all the zip files from CloudBolt /tmp/systemd-private* directory.
+"""
+from common.methods import set_progress
+import glob
+import os
+
+def run(job, *args, **kwargs):
+    
+    zip_file_list = glob.glob("/tmp/systemd-private*/tmp/*.zip")
+    set_progress("Found following zip files in /tmp: {}".format(zip_file_list))
+    for file in zip_file_list:
+        set_progress("Removing these files {}".format(file))
+        os.remove(file)
+
+    return "SUCCESS", "", ""

--- a/actions/cloudbolt_plugins/recurring_jobs/remove_.zip_from_tmp.py
+++ b/actions/cloudbolt_plugins/recurring_jobs/remove_.zip_from_tmp.py
@@ -7,10 +7,10 @@ import os
 import time
 
 def run(job, *args, **kwargs):
-    
     zip_file_list = glob.glob("/tmp/systemd-private*/tmp/*.zip")
     set_progress("Found following zip files in /tmp/systemd/*/tmp: {}".format(zip_file_list))
     for file in zip_file_list:
+        #Only remove zip files that are at least 5 minutes old.
         if os.path.getmtime(file) < time.time() - 5 * 60:
 	   set_progress("Removing these files {}".format(file))
            os.remove(file)


### PR DESCRIPTION
…ystemd* dir

[https://cloudbolt.atlassian.net/browse/DEV-12629]

# Development Prerequisites
- **Developer:** Maryam
- **Partner:** Nick
- **Jira Story:** https://cloudbolt.atlassian.net/browse/DEV-12629
- **Design Doc:**  https://docs.google.com/document/d/13kybR3CCNz6I-ElrKq4XEBUeiiMTlP7gG0Wam_aT4DA/edit?usp=drive_web&ouid=107748304445884863856

## Summary of Proposed Changes
* .Currently, CB leaves unused .zip files in /tmp whenever it creates zip for exporting purposes. As a result, CB /tmp dire gets filled and CB admins either don't know if they should clean up those files or they have to manually clean them. This PR helps them automate the cleanup process and empty some space.
