### PR TITLE
UI Extension for managing Scheduled Snapshots

### DIFF
--- a/ui_extensions/scheduled_snapshots/actions/take_scheduled_snapshots.py
+++ b/ui_extensions/scheduled_snapshots/actions/take_scheduled_snapshots.py
@@ -1,0 +1,86 @@
+from datetime import datetime
+import pycron
+
+from django.template.defaultfilters import pluralize
+from django.utils.html import format_html
+from django.utils.translation import ugettext as _
+
+from common.methods import set_progress
+from infrastructure.models import Server, ServerSnapshot
+from utilities import events
+from utilities.logger import ThreadLogger
+
+logger = ThreadLogger(__name__)
+
+
+def run(job, **kwargs):
+    """
+    Check for any Servers that are scheduled to have a Snapshot taken at this time. For each, take a snapshot
+    (be careful just in case someone somehow configured a Server that doesn't support taking snapshots).
+    Then, check whether the maximum # of snapshots has been exceeded for that Server and, if so, delete
+    the oldest snapshot to return to only having the maximum # (e.g., if the max is 3 and we take a 4th,
+    delete one so we're back to 3). Note that the snapshots considered here are only those created by
+    CB; we do not discover snapshots that exist on the RH but were created separately.
+    """
+    now = datetime.now()
+    snapshot_name = str(now)
+    snapshot_desc = f"Scheduled snapshot taken by Recurring Job at {now}"
+    # If there's no default value for the Action Input yet, go with 3
+    default_max_snapshots = int("{{ snapshot_maximum }}") or 3
+
+    set_progress(f"Searching for Servers that are scheduled to have their snapshot taken now ({now})")
+    # Only consider ACTIVE servers (trying to take snapshots of Servers in other states might not go well)
+    # that have an appropriate value for the schedule parameter and whose RH can manage snapshots
+    active_servers = Server.objects.filter(status="ACTIVE")
+    servers = [
+        s for s in active_servers if
+        s.resource_handler and s.resource_handler.cast().can_manage_snapshots
+        and s.scheduled_snapshot_schedule and pycron.is_now(s.scheduled_snapshot_schedule, now)
+    ]
+
+    if servers:
+        servers_str = ", ".join([svr.hostname for svr in servers])
+        set_progress(
+            f"Taking a snapshot of {len(servers)} Server{pluralize(len(servers))}: {servers_str}"
+        )
+    else:
+        set_progress("No Servers to take a snapshot of right now")
+
+    failures = []
+    for server in servers:
+        # Modified from ServerCreateSnapshotForm
+        rh = server.resource_handler.cast()
+        try:
+            new_snapshot = rh.create_snapshot(server, snapshot_name, snapshot_desc)
+        except Exception:
+            msg = f"Server {server.hostname} failed to create snapshot"
+            logger.exception(msg)
+            failures.append(server.hostname)
+        else:
+            msg = format_html(
+                _("Server snapshot {snapshot} created."),
+                snapshot=new_snapshot.name_with_tooltip,
+            )
+            events.add_server_event("MODIFICATION", server, msg)
+            set_progress(f"Successfully created snapshot for {server.hostname}")
+
+            # If the Server has its own max set, use that. Otherwise, default to the Action Input value
+            max_snapshots = server.scheduled_snapshot_maximum
+            if max_snapshots is None:
+                max_snapshots = default_max_snapshots
+            num_snapshots = ServerSnapshot.objects.filter(server=server).count()
+            if num_snapshots > max_snapshots:
+                snapshots = list(ServerSnapshot.objects.filter(server=server).order_by("-date_created"))
+                snapshots_to_delete = snapshots[max_snapshots:]
+                num_snapshots_to_delete = "one" if len(snapshots_to_delete) == 1 else len(snapshots_to_delete)
+                set_progress(f"With {num_snapshots} snapshots, {server.hostname} has exceeded the "
+                             f"max of {max_snapshots}. Deleting the oldest {num_snapshots_to_delete}")
+                # The None is for profile, since this is run automatically instead of by a User
+                job_created_msg = server.create_delete_snapshots_job(
+                    None, snapshots_to_delete
+                )
+                logger.info(job_created_msg)
+
+    if failures:
+        msg = f"Taking the snapshot failed for at least 1 Server: {', '.join(failures)}"
+        return "FAILURE", "", msg

--- a/ui_extensions/scheduled_snapshots/forms.py
+++ b/ui_extensions/scheduled_snapshots/forms.py
@@ -1,0 +1,159 @@
+import croniter
+import datetime
+import pycron
+
+from django.forms import ValidationError, CharField, widgets
+from django.utils.html import format_html
+
+from common.fields import form_field_for_cf
+from common.forms import C2Form
+from infrastructure.models import CustomField, Server, ServerSnapshot
+from utilities import events
+from utilities.logger import ThreadLogger
+
+logger = ThreadLogger(__name__)
+
+
+class EditServerMaxSnapshotsParameterForm(C2Form):
+    """
+    Form for editing the value of the Maximum # of Snapshots Parameter on the Server
+    """
+    def __init__(self, *args, **kwargs):
+        from xui.scheduled_snapshots.views import MAX_TIP
+
+        self.server = kwargs.pop("server")
+        self.field = CustomField.objects.get(name="scheduled_snapshot_maximum")
+
+        super().__init__(*args, **kwargs)
+
+        self.fields["value"] = form_field_for_cf(self.field, server=self.server)
+        self.fields["value"].help_text = MAX_TIP
+
+    def save(self, profile):
+        new_value = self.cleaned_data["value"]
+        if new_value == "":
+            # The text field was empty, but None is handled better than empty string
+            new_value = None
+
+        self.server.update_cf_value(self.field, new_value, profile)
+        if new_value:
+            msg = f"Maximum # of Snapshots was set to {new_value}."
+        else:
+            msg = "Maximum # of Snapshots was removed for this Server. Will default to Recurring Job value"
+
+        return msg
+
+
+class EditServerSnapshotScheduleParameterForm(C2Form):
+    """
+    Form for editing the value of the Snapshot Schedule Parameter on the Server
+    """
+
+    def __init__(self, *args, **kwargs):
+
+        self.server = kwargs.pop("server")
+        self.field = CustomField.objects.get(name="scheduled_snapshot_schedule")
+
+        super().__init__(*args, **kwargs)
+
+        self.fields["value"] = form_field_for_cf(self.field, server=self.server)
+        self.fields["value"].help_text = (
+            "Cron-style string that specifies when to take a snapshot of this Server. The minutes "
+            "value (the first one) must be 0 to match the Recurring Job running only on the hour"
+        )
+
+    def clean_value(self):
+        """
+        Slight improvement to UX by helping them enter a valid cron-format value
+        """
+        data = self.cleaned_data["value"]
+
+        if data:
+            # Make sure both pycron & croniter can parse this cron schedule. Each chokes on different
+            # formats - ex. croniter does not like "@ @ @ @ @". pycron can't really deal with that
+            # either, it just doesn't raise an exception, so check both here.
+            try:
+                pycron.is_now(data)
+            except ValueError as err:
+                raise ValidationError(str(err).capitalize())
+            try:
+                croniter.croniter(data, datetime.datetime.now())
+            except (ValueError, KeyError) as err:
+                raise ValidationError(str(err).capitalize())
+
+            # Also make sure it's only scheduled to run on the hour, to match Recurring Job run-time.
+            # Apparently it's valid to make the 1st piece multiple 0s (e.g., 00), so take that into account
+            minute = data.split(" ")[0]
+            if not int(minute) == 0:
+                raise ValidationError(
+                    "Only schedules with a 0 minute are valid, since the Recurring Job only "
+                    "runs on the hour"
+                )
+
+        return data
+
+    def save(self, profile):
+        new_value = self.cleaned_data["value"]
+
+        self.server.update_cf_value(self.field, new_value, profile)
+        if new_value:
+            msg = f"Snapshot Schedule was set to {new_value}."
+        else:
+            msg = "Snapshot Schedule was removed for this Server. No snapshots will be automatically taken"
+
+        return msg
+
+
+class ServerCreateSnapshotRespectMaxForm(C2Form):
+    """
+    Form for creating a manual snapshot
+
+    Note: this is very similar to the usual ServerCreateSnapshotForm, but changes
+    the behavior around deleting old snapshots to allow more than one to persist
+    """
+    server_id = CharField(widget=widgets.HiddenInput())
+    name = CharField(label="Name", max_length=50)
+    description = CharField(
+        label="Description",
+        max_length=256,
+        widget=widgets.Textarea(attrs={"rows": 5, "cols": 80}),
+        required=False,
+    )
+
+    def save(self, profile):
+        server_id = self.cleaned_data["server_id"]
+        snapshot_name = self.cleaned_data.get("name")
+        snapshot_desc = self.cleaned_data.get("description")
+        server = Server.objects.get(id=server_id)
+        rh = server.resource_handler.cast()
+        success = False
+
+        try:
+            # The new snapshot is created before deleting the old ones because we want to ensure
+            # that the new one is successfully created before deleting the old.
+            new_snapshot = rh.create_snapshot(server, snapshot_name, snapshot_desc)
+        except Exception:
+            msg = "Server failed to create snapshot"
+            logger.exception(msg)
+        else:
+            success = True
+            msg = format_html(
+                "Server snapshot {snapshot} created.",
+                snapshot=new_snapshot.name_with_tooltip,
+            )
+            events.add_server_event("MODIFICATION", server, msg, profile)
+
+            # If there is a maximum # of snapshots set and that many already exist, delete
+            # older ones. Otherwise, leave them all
+            max_snapshots = server.scheduled_snapshot_maximum
+            if max_snapshots:
+                num_snapshots = ServerSnapshot.objects.filter(server=server).count()
+                if num_snapshots > max_snapshots:
+                    snapshots = list(ServerSnapshot.objects.filter(server=server).order_by("-date_created"))
+                    snapshots_to_delete = snapshots[max_snapshots:]
+                    job_created_msg = server.create_delete_snapshots_job(
+                        profile, snapshots_to_delete
+                    )
+                    msg = format_html("{}{}", msg, job_created_msg)
+
+        return success, msg

--- a/ui_extensions/scheduled_snapshots/templates/server_tab.html
+++ b/ui_extensions/scheduled_snapshots/templates/server_tab.html
@@ -1,0 +1,90 @@
+{% load helper_tags %}
+
+{% if not rec_job.enabled %}
+<div class="alert alert-warning">
+    The "{{ rec_job|link_or_label:profile }}" Recurring Job is disabled. Please enable it or ask your Administrator
+    to do so.
+</div>
+{% endif %}
+<div class="help-block">
+    Scheduled Snapshots are implemented by the "{{ rec_job|link_or_label:profile }}" Recurring Job. In order for a snapshot to be
+    taken on the schedule designated here, that Recurring Job must be enabled and set to run every hour on the hour.
+    {% portal_label %} will use its own server time to judge whether it is the right time to take a scheduled snapshot,
+    so make sure you know what the time is on the {% portal_label %} instance and that the timezone ({% cb_timezone_info %}) is correct.
+</div>
+
+<dl>
+    <dt>Schedule:</dt>
+    <dd>
+        {% if server.scheduled_snapshot_schedule %}
+            {{ server.scheduled_snapshot_schedule }}
+        {% else %}
+            No schedule is set, so no snapshots will be automatically taken for this Server.
+            Use the Edit icon to configure a snapshot schedule.
+        {% endif %}
+        <a href="/snapshots/configure_schedule/{{ server.id }}/" class="open-dialog revealable"><i class="icon-edit"></i></a>
+    </dd>
+    {% if next_snapshot %}
+        <dt>Next Expected Snapshot:</dt>
+        <dd>{{ next_snapshot }}</dd>
+    {% endif %}
+
+    <dt>
+        Maximum # of Snapshots: {% infotip max_tip %}
+    </dt>
+    <dd>
+        {# Setting it to 0 would be an odd choice, but we should respect it and not treat it like being unset #}
+        {% if server.scheduled_snapshot_maximum is not None %}
+            {{ server.scheduled_snapshot_maximum }}
+        {% else %}
+            No maximum number of snapshots is configured for this Server, so the default on the
+            Recurring Job will be used.
+        {% endif %}
+        <a href="/snapshots/configure_max/{{ server.id }}/" class="open-dialog revealable"><i class="icon-edit"></i></a>
+    </dd>
+</dl>
+
+<div class="row">
+    <div class="col-lg-6">
+        <h2>Snapshots {% infotip infotip_text %}</h2>
+    </div>
+    <div class="col-lg-6 text-right">
+        <a class="btn btn-default open-dialog"
+           href="/snapshots/create/{{ server.id }}/"
+            ><span class="icon-add"></span>
+            Create Manual Snapshot
+        </a>
+    </div>
+</div>
+<div id="snapshots" class="panel panel-default">
+    <table id="snapshots-table" width="100%" class="table table-striped table-hover">
+        <thead>
+            <tr>
+                <th>Snapshot</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+        {% for snapshot in details.snapshots.all %}
+            <tr>
+                <td>
+                    {{ snapshot.get_name_with_date_created }}
+                </td>
+                <td>
+                    <a class="open-dialog" title="Revert to"
+                       href="/snapshots/revert/{{ server.id }}/{{ snapshot.id }}/">
+                        <i class="fas fa-undo"></i>
+                    </a>
+                    <a class="open-dialog" title="Delete"
+                       href="{% url 'server_delete_snapshot' server.id snapshot.id %}">
+                        <span class="icon-delete"></span>
+                    </a>
+                </td>
+            </tr>
+        {% empty %}
+            <tr><td>There are no snapshots yet.</td></tr>
+        {% endfor %}
+        </tbody>
+    </table>
+
+</div>

--- a/ui_extensions/scheduled_snapshots/urls.py
+++ b/ui_extensions/scheduled_snapshots/urls.py
@@ -1,0 +1,20 @@
+from django.conf.urls import url
+
+from xui.scheduled_snapshots import views
+
+xui_urlpatterns = [
+    url(r'^snapshots/configure_schedule/(?P<server_id>\d+)/$', views.configure_snapshot_schedule,
+        name='configure_snapshot_schedule'),
+    url(r'^snapshots/configure_max/(?P<server_id>\d+)/$',
+        views.configure_snapshot_max, name='configure_snapshot_max'),
+    url(
+        r"^snapshots/revert/(?P<server_id>\d+)/(?P<snapshot_id>\d+)/$",
+        views.server_revert_to_specific_snapshot,
+        name="server_revert_to_specific_snapshot",
+    ),
+    url(
+        r"^snapshots/create/(?P<server_id>\d+)/$",
+        views.server_create_snapshot_respect_max,
+        name="server_create_snapshot_respect_max",
+    ),
+]

--- a/ui_extensions/scheduled_snapshots/views.py
+++ b/ui_extensions/scheduled_snapshots/views.py
@@ -1,0 +1,333 @@
+import croniter
+import datetime
+import os
+
+from django.conf import settings
+from django.contrib import messages
+from django.http import HttpResponseRedirect
+from django.urls import reverse
+from django.shortcuts import render, get_object_or_404
+from django.utils.html import format_html
+from django.utils.safestring import mark_safe
+from django.utils.translation import ugettext as _
+
+from cbhooks.models import CloudBoltHook
+from extensions.views import tab_extension, TabExtensionDelegate
+from infrastructure.forms import ServerRevertToSnapshotForm
+from infrastructure.models import Server, ServerSnapshot, CustomField
+from jobs.models import RecurringJob
+from utilities.decorators import dialog_view
+from utilities.permissions import get_cb_permissions, server_permission
+from utilities.templatetags.helper_tags import portal_label, when, render_list
+from xui.scheduled_snapshots.forms import (
+    EditServerMaxSnapshotsParameterForm,
+    EditServerSnapshotScheduleParameterForm,
+    ServerCreateSnapshotRespectMaxForm,
+)
+
+
+MAX_TIP = (
+    "The number of scheduled snapshots to take of this Server before beginning to delete the oldest. "
+    "Optionally overrides the default set on the Recurring Job"
+)
+
+
+class ScheduledSnapshotsTabDelegate(TabExtensionDelegate):
+    def should_display(self):
+        """
+        Only show the Scheduled Snapshots Server tab if the Server's RH can manage snapshots and the
+        User has the server.manage_snapshots permission on the Server
+        """
+        rh = self.instance.resource_handler
+        if rh:
+            rh = rh.cast()
+            if rh.can_manage_snapshots:
+                if "server.manage_snapshots" in get_cb_permissions(self.viewer, self.instance):
+                    return True
+
+        return False
+
+
+def get_or_create_required_objects():
+    """
+    Creates the related objects (parameters, Recurring Job) that are needed to support this
+    UI Extension, if needed. If they already exist, just gets them and returns whatever's needed
+    """
+    CustomField.objects.get_or_create(
+        name='scheduled_snapshot_schedule', type='STR',
+        defaults={'label': 'Schedule for Snapshots',
+                  'description': (
+                      'Cron-style timing to take a snapshot of a Server. Only intended for use with the Scheduled '
+                      'Snapshots UI Extension and its associated "Take Scheduled Snapshots" Recurring Job'
+                  )})
+    CustomField.objects.get_or_create(
+        name='scheduled_snapshot_maximum', type='INT',
+        defaults={'label': 'Maximum # of Snapshots',
+                  'description': (
+                        'The number of scheduled snapshots to take of a Server before beginning to delete '
+                        'the oldest. Optionally overrides the default set on the Recurring Job. Only intended '
+                        'for use with the Scheduled Snapshots UI Extension and its associated "Take Scheduled '
+                        'Snapshots" Recurring Job'
+                  )})
+
+    from c2_wrapper import create_hook
+    from initialize.create_objects import create_recurring_job
+    # Use the existing helper methods, but only if the objects don't already exist
+    action = CloudBoltHook.objects.filter(name="Take Scheduled Snapshots").first()
+    if not action:
+        rec_job_action_dict = {
+            "name": "Take Scheduled Snapshots",
+            "description": "Plug-in to support the Recurring Job that takes snapshots that have been scheduled",
+            "hook_point": None,
+            "module": os.path.join(settings.PROSERV_DIR, "xui/scheduled_snapshots/actions/take_scheduled_snapshots.py"),
+            "inputs": [
+                {
+                    "name": "snapshot_maximum",
+                    "label": "Maximum # of Snapshots",
+                    "description": (
+                        "The number of scheduled snapshots to take of a Server before beginning to delete "
+                        "the oldest. Can be overridden by the value set on a specific Server"
+                    ),
+                    "type": "INT",
+                    "namespace": "action_inputs",
+                }
+            ],
+        }
+        create_hook(**rec_job_action_dict)
+    rec_job = RecurringJob.objects.filter(name="Take Scheduled Snapshots").first()
+    if not rec_job:
+        rec_job_dict = {
+            "name": "Take Scheduled Snapshots",
+            "enabled": True,
+            "description": (
+                "This Recurring Job enables scheduling snapshots to be taken of Servers automatically at a "
+                "certain time of day. To use this feature, go to a Server's details page and configure a "
+                "snapshot schedule and potentially override the maximum # of snapshots on the Scheduled "
+                "Snapshots tab added by the UI Extension to supported Servers."
+                "When the action runs it will look for Servers with a schedule set that indicates a snapshot "
+                "should be taken during that hour, then generate a snapshot for each. It will also check "
+                "whether each such Server has reached its maximum # of snapshots, either as set on that "
+                "individual Server or per the default on this Recurring Job, and, if so, delete the oldest "
+                "snapshot known to CloudBolt in order to respect that maximum. "
+                "CloudBolt will use its own server time to judge whether it is the right time to take a "
+                "snapshot, so make sure you know what time it is on the CB server and that the timezone is right. "
+                "Also note that this Recurring Job is expected to be run "
+                "every hour on the hour. If it is run on a different schedule, that will impact "
+                "when snapshots are taken. The snapshot will only happen if the job runs "
+                "during the hour when a snapshot is scheduled."
+            ),
+            "type": "recurring_action",
+            "hook_name": "Take Scheduled Snapshots",
+            # Once/hour at the beginning of the hour
+            "schedule": "0 * * * *",
+        }
+        rec_job = create_recurring_job(rec_job_dict)
+    return rec_job
+
+
+@tab_extension(model=Server, title="Scheduled Snapshots", description="Manage scheduled snapshots",
+               delegate=ScheduledSnapshotsTabDelegate)
+def server_scheduled_snapshots_tab(request, obj_id):
+    """
+    Generates the Server tab for scheduling and managing snapshots.
+    """
+    rec_job = get_or_create_required_objects()
+
+    server = Server.objects.get(id=obj_id)
+    rh = server.get_resource_handler()
+    details = rh.tech_specific_server_details(server)
+
+    portal_lbl = portal_label(context={"request": request})
+    infotip_text = f"All snapshots currently on the Server that have been created with {portal_lbl}"
+    try:
+        iter = croniter.croniter(server.scheduled_snapshot_schedule, datetime.datetime.now())
+        next_time = iter.get_next(datetime.datetime)
+    except (AttributeError, ValueError, KeyError) as err:
+        # If something goes wrong just don't show this info because that most likely means we don't
+        # have a schedule set
+        next_snapshot = None
+    else:
+        next_snapshot = when(next_time)
+
+    return render(request, "scheduled_snapshots/templates/server_tab.html",
+                  {"server": server, "details": details, "portal_lbl": portal_lbl, "infotip_text": infotip_text,
+                   "max_tip": MAX_TIP, "rec_job": rec_job, "next_snapshot": next_snapshot})
+
+
+@dialog_view
+def configure_snapshot_schedule(request, server_id):
+    """
+    Configure a value for the Snapshot Schedule for a Server by editing the corresponding
+    Parameter's value
+    """
+    profile = request.get_user_profile()
+    server = get_object_or_404(Server, pk=server_id)
+
+    if request.method == "GET":
+        form = EditServerSnapshotScheduleParameterForm(server=server)
+
+    else:
+        form = EditServerSnapshotScheduleParameterForm(request.POST, server=server)
+        if form.is_valid():
+            msg = form.save(profile)
+            messages.success(request, msg)
+            return HttpResponseRedirect(reverse("server_detail", args=[server_id]))
+
+    return {
+        "title": _('Edit Snapshot Schedule on Server "{server}"').format(server=server),
+        "form": form,
+        "server": server,
+        "action_url": reverse("configure_snapshot_schedule", args=[server_id]),
+        "submit": _("Save"),
+    }
+
+
+@dialog_view
+def configure_snapshot_max(request, server_id):
+    """
+    Configure a value for the Maximum # of Snapshots for a Server by editing the corresponding
+    Parameter's value
+    """
+    profile = request.get_user_profile()
+    server = get_object_or_404(Server, pk=server_id)
+
+    if request.method == "GET":
+        form = EditServerMaxSnapshotsParameterForm(server=server)
+
+    else:
+        form = EditServerMaxSnapshotsParameterForm(request.POST, server=server)
+        if form.is_valid():
+            msg = form.save(profile)
+            messages.success(request, msg)
+            return HttpResponseRedirect(reverse("server_detail", args=[server_id]))
+
+    return {
+        "title": _('Edit Maximum # of Snapshots on Server "{server}"').format(server=server),
+        "form": form,
+        "server": server,
+        "action_url": reverse("configure_snapshot_max", args=[server_id]),
+        "submit": _("Save"),
+    }
+
+
+@dialog_view
+@server_permission("server.manage_snapshots")
+def server_revert_to_specific_snapshot(request, server_id, snapshot_id):
+    """
+    View for reverting a server to a particular snapshot
+
+    Note: this is very similar to the usual server_revert_to_snapshot, but supports
+    being run on a specific snapshot instead of just the newest. The code is copied
+    rather than refactored so this XUI can work on older versions of CB
+    """
+    snapshot = ServerSnapshot.objects.filter(server_id=server_id, id=snapshot_id).first()
+    prompt = format_html(
+        _("Revert VM to snapshot {snapshot}?"),
+        snapshot=snapshot.get_name_with_date_created(),
+    )
+    info = _(
+        "The current disk and memory states of the VM will be lost. The "
+        "disk state will be replaced with what existed when the snapshot "
+        "was taken."
+    )
+    content = format_html("<p>{}</p> <p>{}</p>", prompt, info)
+
+    if request.method == "POST":
+        profile = request.get_user_profile()
+        form = ServerRevertToSnapshotForm(request.POST)
+
+        if form.is_valid():
+            success, msg = form.save(profile)
+            if success:
+                messages.success(request, msg)
+            else:
+                messages.warning(request, msg)
+            return HttpResponseRedirect(reverse("server_detail", args=[server_id]))
+
+    else:
+        form = ServerRevertToSnapshotForm(
+            initial={"server_id": server_id, "snapshot_id": snapshot_id}
+        )
+
+    return {
+        "title": _("Revert to Snapshot"),
+        "content": content,
+        "form": form,
+        "use_ajax": True,
+        "action_url": reverse("server_revert_to_specific_snapshot", args=[server_id, snapshot_id]),
+        "submit": _("Revert"),
+    }
+
+
+@dialog_view
+@server_permission("server.manage_snapshots")
+def server_create_snapshot_respect_max(request, server_id):
+    """
+    View for creating a new snapshot on a server
+
+    Dialog asks for confirmation then runs synchronous creation of new
+    snapshot, then potentially starts a job to delete old ones asynchronously
+    if there is a maximum set and it has been exceeded
+
+    Note: this is very similar to the usual server_create_snapshot, but changes
+    the behavior around deleting old snapshots to allow more than one to persist
+    """
+    server = get_object_or_404(Server, pk=server_id)
+    content = mark_safe(
+        _(
+            "Create new snapshot of VM at the current location? "
+            "This action allows you to save the state of the server "
+            "so it is possible to revert to it at a later time."
+        )
+    )
+
+    # If there is a maximum # of snapshots set and that many already exist, delete
+    # older ones. Otherwise, leave them all
+    max_snapshots = server.scheduled_snapshot_maximum
+    if max_snapshots:
+        num_snapshots = ServerSnapshot.objects.filter(server=server).count()
+        if num_snapshots >= max_snapshots:
+            snapshots = list(ServerSnapshot.objects.filter(server=server).order_by("-date_created"))
+            snapshots_to_delete = snapshots[(max_snapshots - 1):]
+            warning = format_html(
+                _(
+                    "After the snapshot is created the following snapshots will be "
+                    "permanently deleted:\n{snapshots}"
+                ),
+                snapshots=render_list(
+                    [snap.get_name_with_date_created() for snap in snapshots_to_delete]
+                ),
+            )
+            content += format_html(
+                """
+                <div class="alert alert-warning">
+                  <p>
+                        {warning}
+                  </p>
+                </div>""",
+                warning=warning,
+            )
+
+    if request.method == "POST":
+        profile = request.get_user_profile()
+        form = ServerCreateSnapshotRespectMaxForm(request.POST)
+
+        if form.is_valid():
+            success, msg = form.save(profile)
+            if success:
+                messages.success(request, msg)
+            else:
+                messages.warning(request, msg)
+            return HttpResponseRedirect(reverse("server_detail", args=[server_id]))
+
+    else:
+        form = ServerCreateSnapshotRespectMaxForm(initial={"server_id": server_id})
+
+    return {
+        "title": _("Create Server Snapshot"),
+        "content": content,
+        "form": form,
+        "use_ajax": True,
+        "submit": _("Submit"),
+        "action_url": reverse("server_create_snapshot_respect_max", args=[server_id]),
+    }


### PR DESCRIPTION
This UI Extension includes a Server tab for configuring
the details of scheduled snapshots for each supported Server
(those whose RH can manage snapshots), namely a schedule and
maximum number of snapshots, for users that have permission to
manage snapshots. It also ensures the existence of a Recurring
Job that is used to actually take those snapshots, by running
every hour and looking for Servers scheduled for that hour. The
Recurring Job will also delete old snapshots if the configured
maximum # of snapshots (may default to the Recurring Job's
value) has been exceeded for any Server.

This is intended to replace the usual snapshot functionality
in the product when installed, althought that will only happen
when it is downloaded onto the current version, since that
requires product code changes.

[DEV-16098]

# Development Prerequisites
- **Developer:** @lpercival 
- **Partner:** @hciudad 
- **Jira Story:** [DEV-16098](https://cloudbolt.atlassian.net/browse/DEV-16098)
