### PR TITLE
[DEV-18680] Set wrapper.region_name

### DIFF
--- a/blueprints/aws_s3_bucket/delete.py
+++ b/blueprints/aws_s3_bucket/delete.py
@@ -9,15 +9,18 @@ def run(**kwargs):
     resource = kwargs.pop('resources').first()
 
     bucket_name = resource.s3_bucket_name
-    rh_id = resource.aws_rh_id
-    rh = AWSHandler.objects.get(id=rh_id)
-    wrapper = rh.get_api_wrapper()
+
+    aws = AWSHandler.objects.get(id=resource.aws_rh_id)
+    set_progress("This resource belongs to {}".format(aws))
+
+    wrapper = aws.get_api_wrapper()
+    wrapper.region_name = resource.s3_bucket_region
 
     set_progress('Connecting to Amazon S3...')
     conn = wrapper.get_boto3_resource(
-        rh.serviceaccount,
-        rh.servicepasswd,
-        None,
+        aws.serviceaccount,
+        aws.servicepasswd,
+        wrapper.region_name,
         service_name='s3'
     )
 

--- a/blueprints/aws_s3_bucket/management/copy_s3_object.py
+++ b/blueprints/aws_s3_bucket/management/copy_s3_object.py
@@ -9,13 +9,15 @@ def run(job, resource, **kwargs):
     destination_bucket = "{{ destination_bucket }}"
 
     aws = AWSHandler.objects.get(id=resource.aws_rh_id)
-    wrapper = aws.get_api_wrapper()
     set_progress("This resource belongs to {}".format(aws))
+
+    wrapper = aws.get_api_wrapper()
+    wrapper.region_name = resource.s3_bucket_region
 
     s3 = wrapper.get_boto3_resource(
         aws.serviceaccount,
         aws.servicepasswd,
-        None,
+        wrapper.region_name,
         service_name='s3'
     )
     copy_source = {

--- a/blueprints/aws_s3_bucket/management/delete_multiple_object.py
+++ b/blueprints/aws_s3_bucket/management/delete_multiple_object.py
@@ -11,14 +11,16 @@ def run(job, resource, **kwargs):
     bucket = resource.s3_bucket_name
 
     aws = AWSHandler.objects.get(id=resource.aws_rh_id)
-    wrapper = aws.get_api_wrapper()
     set_progress("This resource belongs to {}".format(aws))
+
+    wrapper = aws.get_api_wrapper()
+    wrapper.region_name = resource.s3_bucket_region
 
     client = wrapper.get_boto3_client(
         's3',
         aws.serviceaccount,
         aws.servicepasswd,
-        None
+        wrapper.region_name
     )
     names = objects.split(',')
 

--- a/blueprints/aws_s3_bucket/management/delete_single_object.py
+++ b/blueprints/aws_s3_bucket/management/delete_single_object.py
@@ -10,13 +10,17 @@ def generate_options_for_obj_name(server=None, **kwargs):
 
     if resource:
         aws = AWSHandler.objects.get(id=resource.aws_rh_id)
+
         wrapper = aws.get_api_wrapper()
+        wrapper.region_name = resource.s3_bucket_region
+
         bucket_name = resource.s3_bucket_name
+
         client = wrapper.get_boto3_client(
             's3',
             aws.serviceaccount,
             aws.servicepasswd,
-            None
+            wrapper.region_name
         )
         buckets = client.list_objects(Bucket=bucket_name).get('Contents', None)
         if buckets:

--- a/blueprints/aws_s3_bucket/management/download_s3_object.py
+++ b/blueprints/aws_s3_bucket/management/download_s3_object.py
@@ -9,13 +9,15 @@ def run(job, resource, **kwargs):
     objects = "{{ objects }}"
 
     aws = AWSHandler.objects.get(id=resource.aws_rh_id)
-    wrapper = aws.get_api_wrapper()
     set_progress("This resource belongs to {}".format(aws))
+    
+    wrapper = aws.get_api_wrapper()
+    wrapper.region_name = resource.s3_bucket_region
 
     s3 = wrapper.get_boto3_resource(
         aws.serviceaccount,
         aws.servicepasswd,
-        None,
+        wrapper.region_name,
         service_name='s3'
     )
     not_downloaded = []

--- a/blueprints/aws_s3_bucket/management/list_objects.py
+++ b/blueprints/aws_s3_bucket/management/list_objects.py
@@ -24,14 +24,16 @@ def run(job, resource, **kwargs):
     bucket = resource.s3_bucket_name
 
     aws = AWSHandler.objects.get(id=resource.aws_rh_id)
-    wrapper = aws.get_api_wrapper()
     set_progress("This resource belongs to {}".format(aws))
+    
+    wrapper = aws.get_api_wrapper()
+    wrapper.region_name = resource.s3_bucket_region
 
     client = wrapper.get_boto3_client(
         's3',
         aws.serviceaccount,
         aws.servicepasswd,
-        None
+        wrapper.region_name
     )
     res = get_all_objects(client, bucket)
     set_progress(res)

--- a/blueprints/aws_s3_bucket/management/list_s3_objects.py
+++ b/blueprints/aws_s3_bucket/management/list_s3_objects.py
@@ -28,15 +28,18 @@ def run(job, resource, **kwargs):
     set_progress("Connecting to AWS s3 cloud")
 
     aws = AWSHandler.objects.get(id=resource.aws_rh_id)
-    wrapper = aws.get_api_wrapper()
     set_progress("This resource belongs to {}".format(aws))
 
+    wrapper = aws.get_api_wrapper()
+    wrapper.region_name = resource.s3_bucket_region
+    
     bucket_name = resource.s3_bucket_name
+    
     client = wrapper.get_boto3_client(
         's3',
         aws.serviceaccount,
         aws.servicepasswd,
-        None
+        wrapper.region_name
     )
 
     rt = create_resource_type_if_needed()

--- a/blueprints/aws_s3_bucket/management/upload-file-object.py
+++ b/blueprints/aws_s3_bucket/management/upload-file-object.py
@@ -6,8 +6,10 @@ def run(job, resource, **kwargs):
     set_progress("Connecting to AWS s3 cloud")
 
     aws = AWSHandler.objects.get(id=resource.aws_rh_id)
-    wrapper = aws.get_api_wrapper()
     set_progress("This resource belongs to {}".format(aws))
+    
+    wrapper = aws.get_api_wrapper()
+    wrapper.region_name = resource.s3_bucket_region
 
     file = "{{ file }}"
     key_name = "{{ name }}"
@@ -15,7 +17,7 @@ def run(job, resource, **kwargs):
     s3 = wrapper.get_boto3_resource(
         aws.serviceaccount,
         aws.servicepasswd,
-        None,
+        wrapper.region_name,
         service_name='s3'
     )
     try:

--- a/blueprints/aws_s3_bucket/management/upload_object.py
+++ b/blueprints/aws_s3_bucket/management/upload_object.py
@@ -6,8 +6,10 @@ def run(job, resource, **kwargs):
     set_progress("Connecting to AWS s3 cloud")
 
     aws = AWSHandler.objects.get(id=resource.aws_rh_id)
-    wrapper = aws.get_api_wrapper()
     set_progress("This resource belongs to {}".format(aws))
+    
+    wrapper = aws.get_api_wrapper()
+    wrapper.region_name = resource.s3_bucket_region
 
     path_name = "{{ path }}"
     upload_to = "{{ name }}"
@@ -15,7 +17,7 @@ def run(job, resource, **kwargs):
     s3 = wrapper.get_boto3_resource(
         aws.serviceaccount,
         aws.servicepasswd,
-        None,
+        wrapper.region_name,
         service_name='s3'
     )
     s3.meta.client.upload_file(path_name, resource.s3_bucket_name, upload_to)


### PR DESCRIPTION
Set wrapper.region_name to be resource.s3_bucket_region. 

Do this before boto3 client is initialized so that we are sure to use the same region/bucket combination that is exposed on the resource/service level.

Without this, we will often default to ‘us-east-1’ which may or may not be the correct region.

# Development Prerequisites
- **Developer:** @ignacious 
- **Partner:** @MISSING_NAME
- **Jira Story:** https://cloudbolt.atlassian.net/browse/DEV-18680
- **Design Doc:** [Design Doc](DESIGN_DOC_URL)

## Testing

Follow steps in https://cloudbolt.atlassian.net/browse/DEV-18680 .
For the BP with  actions, use 
[aws_s3_bucket_content_dev.zip](https://github.com/CloudBoltSoftware/cloudbolt-forge/files/6388296/aws_s3_bucket_content_dev.zip) . This was got from `content-dev.cloudbolt.io` using Content Library. I had to curate this a bit since a number of other actions were included on account of Content Dev having many versions of the same action.

This was exported from https://10.55.60.111 which should be accessible. See @ignacious for login if needed.

Create/List/Delete should work without errors.
