### PR TITLE
[DEV-19829] - Openshift XUI Verify Connection Error

### DIFF
--- a/ui_extensions/openshift/openshiftmanager.py
+++ b/ui_extensions/openshift/openshiftmanager.py
@@ -6,7 +6,7 @@ from utilities.models import ConnectionInfo
 class OpenshiftManager:
     def __init__(self, host=None, token=None, port=443, protocol='https'):
         """API Object Constructor."""
-        self.BASE_URL = '{}://{}:{}/oapi/v1'.format(protocol, host, port)
+        self.BASE_URL = f'{protocol}://{host}:{port}/apis/'
         self.host = host
         self.token = token
         self.headers = {

--- a/ui_extensions/openshift/views.py
+++ b/ui_extensions/openshift/views.py
@@ -69,7 +69,8 @@ def add_credentials(request):
 def verify_credentials(request):
     openshift_manager = OpenshiftManager()
     openshift_ci = openshift_manager.get_connection_info()
-    openshift = OpenshiftManager(openshift_ci.ip, openshift_manager.get_token())
+    token = openshift_manager.get_token()
+    openshift = OpenshiftManager(openshift_ci.ip, token, openshift_ci.port, openshift_ci.protocol)
     response = openshift.verify_rest_credentials()
 
     if response:


### PR DESCRIPTION
* Fixed the code to work with version 4.6 of Openshift.
* Corrected verify connection to use port and protocol from the CI object.

# Development Prerequisites
- **Developer:** @laltomar 
- **Jira Story:** [DEV-19829]https://cloudbolt.atlassian.net/browse/DEV-19829

## Summary of Proposed Changes
* Update Openshift XUI code to support Openshift Version 4.6, this change will need to be tested against the SaaS version of Openshift.


[DEV-19829]: https://cloudbolt.atlassian.net/browse/DEV-19829