### PR TITLE
Fixed code to populate the storage accounts based on the selected Resource Group and sync issue

### DIFF
--- a/blueprints/azure_storage_container/create.py
+++ b/blueprints/azure_storage_container/create.py
@@ -57,8 +57,8 @@ def generate_options_for_storage_accounts(control_value=None, **kwargs):
         )
         azure_client = storage.StorageManagementClient(credentials, handler.serviceaccount)
         set_progress("Connection to Azure established")
-        for st in azure_client.storage_accounts.list():
-            storage_accounts.append(st.name)
+        for st in azure_client.storage_accounts.list_by_resource_group(control_value)._get_next().json()['value']:
+            storage_accounts.append(st['name'])
     return storage_accounts
 
 def generate_options_for_permissions(**kwargs):
@@ -118,6 +118,7 @@ def run(job, *args, **kwargs):
     client = storage.StorageManagementClient(credentials, rh.serviceaccount)
     
     resource.name = container_name
+    resource.azure_container_id = container_name + '-' + storage_account
     resource.azure_account_name = storage_account
     resource.azure_container_name = container_name
     resource.resource_group_name = resource_group

--- a/blueprints/azure_storage_container/sync.py
+++ b/blueprints/azure_storage_container/sync.py
@@ -41,10 +41,10 @@ def discover_resources(**kwargs):
                         keys = res.keys
                         containers.append(
                             {
-                                'azure_container_id' : container['id'],
+                                'name' : container['name'],
+                                'azure_container_id' : container['name'] + '-' + account['name'],
                                 'azure_rh_id':handler.id,
                                 'azure_account_name':account['name'],
-                                'azure_container_name':container['name'],
                                 'azure_account_key':keys[0].value,
                                 'resource_group_name':resource_group.name,
                                 'azure_location': account['location']


### PR DESCRIPTION
# Development Prerequisites
- **Developer:** @yogeshmhaskule93 
- **Partner:** None
- **Jira Story:** [DEV-20544](https://cloudbolt.atlassian.net/browse/DEV-20544)
- **Design Doc:** None

## Summary of Proposed Changes
1. Fixed code to populate the storage accounts based on the selected resource group 
2. Fixed the issue duplicate entry of the order resource with group 'Unassigned' after executing the sync resource job
